### PR TITLE
Bug fix: hostname system call can return multiple IP addresses, causing invalid IP-addresses

### DIFF
--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -98,8 +98,7 @@ export async function getIP() {
         stdout: "piped",
       });
 
-      const ip = new TextDecoder().decode(await process.output()).trim();
-
+      const ip = new TextDecoder().decode(await process.output()).trim().split(" ")[0];
       return ip.length ? ip : null;
     }
 


### PR DESCRIPTION
This issue breaks hot-reloading in the cli template on linux currently if `hostname -I` return more than one IP address, and will probably cause further issues if not fixed. 
