### PR TITLE
fix(install): Allow for spaces in Deno.execPath

### DIFF
--- a/install.ts
+++ b/install.ts
@@ -17,7 +17,8 @@ import "https://cdn.skypack.dev/svelte@3.44.2/store";
 const install = async (name: string, url: string, importmap?: boolean) => {
   const process = Deno.run({
     cmd: [
-      ...`${Deno.execPath()} install -q -A -f -r --no-check${
+      Deno.execPath(),
+      ...`install -q -A -f -r --no-check${
         importmap
           ? ` --import-map=https://deno.land/x/${name}/import_map.json`
           : ""


### PR DESCRIPTION
The execPath was getting chopped if it had spaces in it. This space mishap is apparently the cause for [PermissionDenied: Zugriff verweigert (os error 5) when installing snel via deno](https://stackoverflow.com/questions/70799905/permissiondenied-zugriff-verweigert-os-error-5-when-installing-snel-via-deno). There might be other spacing concerns in the command, since `.split(' ')` is not really a good way of building the `cmd` array, but overall the rest of cmd seems pretty ok to me.

The poster confirmed in Discord that their execPath has a space in it, and [that this patch worked](https://discord.com/channels/684898665143206084/689420767620104201/934436958661410827) for them.