### PR TITLE
Fix install issue due to drollup

### DIFF
--- a/src/shared/internal_plugins.ts
+++ b/src/shared/internal_plugins.ts
@@ -10,7 +10,7 @@ import { loadConfig, resolverConfigFile } from "./utils.ts";
 import type { snelConfig } from "../shared/types.ts";
 import server from "../dev_server/server.ts";
 
-export { terser } from "https://denopkg.com/buttercubz/deno-rollup@next/plugins/terser/mod.ts";
+export { terser } from "https://deno.land/x/drollup@2.58.0+0.20.0/plugins/terser/mod.ts";
 export { default as Svelte } from "./bundler.js";
 export * from "./import_map.ts";
 


### PR DESCRIPTION
The `@next` version of https://github.com/cmorten/deno-rollup does not provide any package when creating a new Snel project, resulting in the error

>error: Module not found "https://denopkg.com/buttercubz/deno-rollup@next/plugins/terser/mod.ts".
>    at https://deno.land/x/snel@v0.7.1/src/shared/internal_plugins.ts:13:24

This _should_ hopefully fix the issue

Fixes #59 